### PR TITLE
Restore DirectDraw mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ CMakeCache.txt
 .vs/
 Debug/
 Release/
+
+*.7z
+*.rar
+*.zip

--- a/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw.cc
+++ b/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw.cc
@@ -1,0 +1,220 @@
+/**
+ * SlashGaming Diablo II Free Display Fix
+ * Copyright (C) 2019  Mir Drualga
+ *
+ * This file is part of SlashGaming Diablo II Free Display Fix.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Additional permissions under GNU Affero General Public License version 3
+ *  section 7
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with Diablo II (or a modified version of that game and its
+ *  libraries), containing parts covered by the terms of Blizzard End User
+ *  License Agreement, the licensors of this Program grant you additional
+ *  permission to convey the resulting work. This additional permission is
+ *  also extended to any combination of expansions, mods, and remasters of
+ *  the game.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any Graphics Device Interface (GDI), DirectDraw, Direct3D,
+ *  Glide, OpenGL, or Rave wrapper (or modified versions of those
+ *  libraries), containing parts not covered by a compatible license, the
+ *  licensors of this Program grant you additional permission to convey the
+ *  resulting work.
+ *
+ *  If you modify this Program, or any covered work, by linking or combining
+ *  it with any library (or a modified version of that library) that links
+ *  to Diablo II (or a modified version of that game and its libraries),
+ *  containing parts not covered by a compatible license, the licensors of
+ *  this Program grant you additional permission to convey the resulting
+ *  work.
+ */
+
+#include "game_restore_ddraw.hpp"
+
+#include <windows.h>
+
+#include <sgd2mapi.hpp>
+
+namespace sgd2fdf::patches {
+namespace {
+
+#pragma pack(push, 1)
+
+struct ConfigOptions_1_14A {
+  mapi::UndefinedByte unkown_0x00[0x04 - 0x00];
+  mapi::bool8 is_use_gdi;
+  mapi::UndefinedByte unknown_0x05[0x06 - 0x05];
+  mapi::bool8 is_use_glide;
+  mapi::bool8 is_use_unknown_video_mode;
+  mapi::UndefinedByte unknown_0x08[0x09 - 0x08];
+  mapi::bool8 is_use_direct3d_else_ddraw;
+  mapi::UndefinedByte unknown_0x0A[0x3C9 - 0x0A];
+};
+
+struct ConfigOptions_1_14D {
+  mapi::UndefinedByte unkown_0x00[0x08 - 0x00];
+  mapi::bool8 is_use_gdi;
+  mapi::UndefinedByte unknown_0x09[0x0A - 0x09];
+  mapi::bool8 is_use_glide;
+  mapi::bool8 is_use_unknown_video_mode;
+  mapi::UndefinedByte unknown_0x0C[0x0D - 0x0C];
+  mapi::bool8 is_use_direct3d_else_ddraw;
+  mapi::UndefinedByte unknown_0x0E[0x3CD - 0x0E];
+};
+
+#pragma pack(pop)
+
+static_assert(sizeof(ConfigOptions_1_14A) == 969);
+static_assert(sizeof(ConfigOptions_1_14D) == 973);
+
+template <typename T>
+void SetVideoModeFlags_Impl(T& config_options, DWORD reg_video_mode) {
+  switch (reg_video_mode) {
+    case 1: {
+      config_options.is_use_direct3d_else_ddraw = true;
+      break;
+    }
+
+    case 2: {
+      config_options.is_use_unknown_video_mode = true;
+      break;
+    }
+
+    case 3: {
+      config_options.is_use_glide = true;
+      break;
+    }
+
+    case 4: {
+      config_options.is_use_gdi = true;
+      break;
+    }
+  }
+}
+
+void SetVideoModeFlags(ConfigOptions& config_options, DWORD reg_video_mode) {
+  switch (d2::GetRunningGameVersionId()) {
+    case d2::GameVersion::kClassic1_14A:
+    case d2::GameVersion::kLod1_14A:
+    case d2::GameVersion::kClassic1_14B:
+    case d2::GameVersion::kLod1_14B:
+    case d2::GameVersion::kClassic1_14C:
+    case d2::GameVersion::kLod1_14C: {
+      SetVideoModeFlags_Impl(
+          reinterpret_cast<ConfigOptions_1_14A&>(config_options),
+          reg_video_mode
+      );
+      break;
+    }
+
+    case d2::GameVersion::kLod1_14D:
+    case d2::GameVersion::kClassic1_14D: {
+      SetVideoModeFlags_Impl(
+          reinterpret_cast<ConfigOptions_1_14D&>(config_options),
+          reg_video_mode
+      );
+      break;
+    }
+  }
+}
+
+template <typename T>
+bool IsVideoModeCmdLineSet_Impl(const T& config_options) {
+  return config_options.is_use_direct3d_else_ddraw
+      && config_options.is_use_unknown_video_mode
+      && config_options.is_use_glide
+      && config_options.is_use_gdi;
+}
+
+bool IsVideoModeCmdLineSet(const ConfigOptions& config_options) {
+  switch (d2::GetRunningGameVersionId()) {
+    case d2::GameVersion::kClassic1_14A:
+    case d2::GameVersion::kLod1_14A:
+    case d2::GameVersion::kClassic1_14B:
+    case d2::GameVersion::kLod1_14B:
+    case d2::GameVersion::kClassic1_14C:
+    case d2::GameVersion::kLod1_14C: {
+      return IsVideoModeCmdLineSet_Impl(
+          reinterpret_cast<const ConfigOptions_1_14A&>(config_options)
+      );
+    }
+
+    case d2::GameVersion::kLod1_14D:
+    case d2::GameVersion::kClassic1_14D: {
+      return IsVideoModeCmdLineSet_Impl(
+          reinterpret_cast<const ConfigOptions_1_14D&>(config_options)
+      );
+    }
+  }
+}
+
+} // namespace
+
+void __cdecl SGD2FDF_Game_ReadRegistryVideoMode(
+    ConfigOptions* config_options
+) {
+  if (IsVideoModeCmdLineSet(*config_options)) {
+    return;
+  }
+
+  // Read the key.
+  HKEY key_handle;
+
+  LSTATUS open_key_status = RegOpenKeyExW(
+      HKEY_CURRENT_USER,
+      L"SOFTWARE\\Blizzard Entertainment\\Diablo II\\VideoConfig",
+      0,
+      KEY_QUERY_VALUE,
+      &key_handle
+  );
+
+  if (open_key_status != ERROR_SUCCESS) {
+    open_key_status = RegOpenKeyExW(
+        HKEY_LOCAL_MACHINE,
+        L"SOFTWARE\\Blizzard Entertainment\\Diablo II\\VideoConfig",
+        0,
+        KEY_QUERY_VALUE,
+        &key_handle
+    );
+
+    if (open_key_status != ERROR_SUCCESS) {
+      return;
+    }
+  }
+
+  // Get the video mode value from the registry.
+  DWORD reg_video_mode = 0;
+  DWORD data_type = 0;
+
+  LSTATUS query_key_status = RegQueryValueExW(
+      key_handle,
+      L"Render",
+      nullptr,
+      &data_type,
+      reinterpret_cast<LPBYTE>(&reg_video_mode),
+      nullptr
+  );
+
+  // Set the video flags.
+  if (query_key_status == ERROR_SUCCESS) {
+    SetVideoModeFlags(*config_options, reg_video_mode);
+  }
+
+  RegCloseKey(key_handle);
+}
+
+} // namespace sgd2fdf::patches

--- a/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw.hpp
+++ b/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw.hpp
@@ -43,61 +43,21 @@
  *  work.
  */
 
-#include "required_patches.hpp"
+#ifndef SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_HPP_
+#define SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_HPP_
 
-#include <algorithm>
+#include <windows.h>
 
-#include "d2ddraw_fix_corner_text_patch/d2ddraw_fix_corner_text_patch.hpp"
-#include "d2direct3d_fix_corner_text_patch/d2direct3d_fix_corner_text_patch.hpp"
-#include "d2direct3d_fix_display_mode_color_bits_patch/d2direct3d_fix_display_mode_color_bits_patch.hpp"
-#include "d2glide_fix_corner_text_patch/d2glide_fix_corner_text_patch.hpp"
-#include "game_restore_ddraw_patch/game_restore_ddraw_patch.hpp"
+#include <sgd2mapi.hpp>
 
 namespace sgd2fdf::patches {
 
-std::vector<mapi::GamePatch> MakeRequiredPatches() {
-  std::vector<mapi::GamePatch> game_patches;
+struct ConfigOptions;
 
-  std::vector d2ddraw_fix_corner_text_patch =
-      Make_D2DDraw_FixCornerTextPatch();
-  game_patches.insert(
-      game_patches.end(),
-      std::make_move_iterator(d2ddraw_fix_corner_text_patch.begin()),
-      std::make_move_iterator(d2ddraw_fix_corner_text_patch.end())
-  );
-
-  std::vector d2direct3d_fix_corner_text_patch =
-      Make_D2Direct3D_FixCornerTextPatch();
-  game_patches.insert(
-      game_patches.end(),
-      std::make_move_iterator(d2direct3d_fix_corner_text_patch.begin()),
-      std::make_move_iterator(d2direct3d_fix_corner_text_patch.end())
-  );
-
-  std::vector d2direct3d_fix_display_mode_color_bits_patch =
-      Make_D2Direct3D_FixDisplayModeColorBitsPatch();
-  game_patches.insert(
-      game_patches.end(),
-      std::make_move_iterator(d2direct3d_fix_display_mode_color_bits_patch.begin()),
-      std::make_move_iterator(d2direct3d_fix_display_mode_color_bits_patch.end())
-  );
-
-  std::vector d2glide_fix_corner_text_patch =
-      Make_D2Glide_FixCornerTextPatch();
-  game_patches.insert(
-      game_patches.end(),
-      std::make_move_iterator(d2glide_fix_corner_text_patch.begin()),
-      std::make_move_iterator(d2glide_fix_corner_text_patch.end())
-  );
-
-  std::vector game_restore_ddraw_patch = Make_Game_RestoreDDrawPatch();
-  game_patches.insert(
-      game_patches.end(),
-      std::make_move_iterator(game_restore_ddraw_patch.begin()),
-      std::make_move_iterator(game_restore_ddraw_patch.end())
-  );
-
-  return game_patches;
-}
+extern "C" void __cdecl SGD2FDF_Game_ReadRegistryVideoMode(
+    ConfigOptions* config_options
+);
 
 } // namespace sgd2fdf::patches
+
+#endif // SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_HPP_

--- a/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw_patch.cc
+++ b/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw_patch.cc
@@ -43,61 +43,48 @@
  *  work.
  */
 
-#include "required_patches.hpp"
+#include "game_restore_ddraw_patch.hpp"
 
-#include <algorithm>
-
-#include "d2ddraw_fix_corner_text_patch/d2ddraw_fix_corner_text_patch.hpp"
-#include "d2direct3d_fix_corner_text_patch/d2direct3d_fix_corner_text_patch.hpp"
-#include "d2direct3d_fix_display_mode_color_bits_patch/d2direct3d_fix_display_mode_color_bits_patch.hpp"
-#include "d2glide_fix_corner_text_patch/d2glide_fix_corner_text_patch.hpp"
-#include "game_restore_ddraw_patch/game_restore_ddraw_patch.hpp"
+#include "game_restore_ddraw_patch_lod_1_14c.hpp"
 
 namespace sgd2fdf::patches {
 
-std::vector<mapi::GamePatch> MakeRequiredPatches() {
-  std::vector<mapi::GamePatch> game_patches;
+std::vector<mapi::GamePatch> Make_Game_RestoreDDrawPatch() {
+  d2::GameVersion running_game_version_id = d2::GetRunningGameVersionId();
 
-  std::vector d2ddraw_fix_corner_text_patch =
-      Make_D2DDraw_FixCornerTextPatch();
-  game_patches.insert(
-      game_patches.end(),
-      std::make_move_iterator(d2ddraw_fix_corner_text_patch.begin()),
-      std::make_move_iterator(d2ddraw_fix_corner_text_patch.end())
-  );
+  switch (running_game_version_id) {
+    /*case d2::GameVersion::kClassic1_14A: {
+      return Make_D2DDraw_FixCornerTextPatch_Classic1_14A();
+    }
 
-  std::vector d2direct3d_fix_corner_text_patch =
-      Make_D2Direct3D_FixCornerTextPatch();
-  game_patches.insert(
-      game_patches.end(),
-      std::make_move_iterator(d2direct3d_fix_corner_text_patch.begin()),
-      std::make_move_iterator(d2direct3d_fix_corner_text_patch.end())
-  );
+    case d2::GameVersion::kLod1_14A: {
+      return Make_D2DDraw_FixCornerTextPatch_LoD1_14A();
+    }
 
-  std::vector d2direct3d_fix_display_mode_color_bits_patch =
-      Make_D2Direct3D_FixDisplayModeColorBitsPatch();
-  game_patches.insert(
-      game_patches.end(),
-      std::make_move_iterator(d2direct3d_fix_display_mode_color_bits_patch.begin()),
-      std::make_move_iterator(d2direct3d_fix_display_mode_color_bits_patch.end())
-  );
+    case d2::GameVersion::kClassic1_14B: {
+      return Make_D2DDraw_FixCornerTextPatch_Classic1_14B();
+    }
 
-  std::vector d2glide_fix_corner_text_patch =
-      Make_D2Glide_FixCornerTextPatch();
-  game_patches.insert(
-      game_patches.end(),
-      std::make_move_iterator(d2glide_fix_corner_text_patch.begin()),
-      std::make_move_iterator(d2glide_fix_corner_text_patch.end())
-  );
+    case d2::GameVersion::kLod1_14B: {
+      return Make_D2DDraw_FixCornerTextPatch_LoD1_14B();
+    }
 
-  std::vector game_restore_ddraw_patch = Make_Game_RestoreDDrawPatch();
-  game_patches.insert(
-      game_patches.end(),
-      std::make_move_iterator(game_restore_ddraw_patch.begin()),
-      std::make_move_iterator(game_restore_ddraw_patch.end())
-  );
+    case d2::GameVersion::kClassic1_14C: {
+      return Make_D2DDraw_FixCornerTextPatch_Classic1_14C();
+    }*/
 
-  return game_patches;
+    case d2::GameVersion::kLod1_14C: {
+      return Make_Game_RestoreDDrawPatch_LoD1_14C();
+    }
+
+    /*case d2::GameVersion::kClassic1_14D: {
+      return Make_D2DDraw_FixCornerTextPatch_Classic1_14D();
+    }
+
+    case d2::GameVersion::kLod1_14D: {
+      return Make_D2DDraw_FixCornerTextPatch_LoD1_14D();
+    }*/
+  }
 }
 
 } // namespace sgd2fdf::patches

--- a/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw_patch.hpp
+++ b/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw_patch.hpp
@@ -43,61 +43,17 @@
  *  work.
  */
 
-#include "required_patches.hpp"
+#ifndef SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_PATCH_HPP_
+#define SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_PATCH_HPP_
 
-#include <algorithm>
+#include <vector>
 
-#include "d2ddraw_fix_corner_text_patch/d2ddraw_fix_corner_text_patch.hpp"
-#include "d2direct3d_fix_corner_text_patch/d2direct3d_fix_corner_text_patch.hpp"
-#include "d2direct3d_fix_display_mode_color_bits_patch/d2direct3d_fix_display_mode_color_bits_patch.hpp"
-#include "d2glide_fix_corner_text_patch/d2glide_fix_corner_text_patch.hpp"
-#include "game_restore_ddraw_patch/game_restore_ddraw_patch.hpp"
+#include <sgd2mapi.hpp>
 
 namespace sgd2fdf::patches {
 
-std::vector<mapi::GamePatch> MakeRequiredPatches() {
-  std::vector<mapi::GamePatch> game_patches;
-
-  std::vector d2ddraw_fix_corner_text_patch =
-      Make_D2DDraw_FixCornerTextPatch();
-  game_patches.insert(
-      game_patches.end(),
-      std::make_move_iterator(d2ddraw_fix_corner_text_patch.begin()),
-      std::make_move_iterator(d2ddraw_fix_corner_text_patch.end())
-  );
-
-  std::vector d2direct3d_fix_corner_text_patch =
-      Make_D2Direct3D_FixCornerTextPatch();
-  game_patches.insert(
-      game_patches.end(),
-      std::make_move_iterator(d2direct3d_fix_corner_text_patch.begin()),
-      std::make_move_iterator(d2direct3d_fix_corner_text_patch.end())
-  );
-
-  std::vector d2direct3d_fix_display_mode_color_bits_patch =
-      Make_D2Direct3D_FixDisplayModeColorBitsPatch();
-  game_patches.insert(
-      game_patches.end(),
-      std::make_move_iterator(d2direct3d_fix_display_mode_color_bits_patch.begin()),
-      std::make_move_iterator(d2direct3d_fix_display_mode_color_bits_patch.end())
-  );
-
-  std::vector d2glide_fix_corner_text_patch =
-      Make_D2Glide_FixCornerTextPatch();
-  game_patches.insert(
-      game_patches.end(),
-      std::make_move_iterator(d2glide_fix_corner_text_patch.begin()),
-      std::make_move_iterator(d2glide_fix_corner_text_patch.end())
-  );
-
-  std::vector game_restore_ddraw_patch = Make_Game_RestoreDDrawPatch();
-  game_patches.insert(
-      game_patches.end(),
-      std::make_move_iterator(game_restore_ddraw_patch.begin()),
-      std::make_move_iterator(game_restore_ddraw_patch.end())
-  );
-
-  return game_patches;
-}
+std::vector<mapi::GamePatch> Make_Game_RestoreDDrawPatch();
 
 } // namespace sgd2fdf::patches
+
+#endif // SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_PATCH_HPP_

--- a/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw_patch_classic_1_14a.hpp
+++ b/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw_patch_classic_1_14a.hpp
@@ -43,39 +43,17 @@
  *  work.
  */
 
-#include "game_restore_ddraw_patch.hpp"
+#ifndef SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_PATCH_CLASSIC_1_14A_HPP_
+#define SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_PATCH_CLASSIC_1_14A_HPP_
 
-#include "game_restore_ddraw_patch_classic_1_14a.hpp"
-#include "game_restore_ddraw_patch_classic_1_14d.hpp"
-#include "game_restore_ddraw_patch_lod_1_14a.hpp"
-#include "game_restore_ddraw_patch_lod_1_14d.hpp"
+#include <vector>
+
+#include <sgd2mapi.hpp>
 
 namespace sgd2fdf::patches {
 
-std::vector<mapi::GamePatch> Make_Game_RestoreDDrawPatch() {
-  d2::GameVersion running_game_version_id = d2::GetRunningGameVersionId();
+std::vector<mapi::GamePatch> Make_Game_RestoreDDrawPatch_Classic1_14A();
 
-  switch (running_game_version_id) {
-    case d2::GameVersion::kClassic1_14A:
-    case d2::GameVersion::kClassic1_14B:
-    case d2::GameVersion::kClassic1_14C: {
-      return Make_Game_RestoreDDrawPatch_Classic1_14A();
-    }
+} // namespace SGD2FDF::patches
 
-    case d2::GameVersion::kLod1_14A:
-    case d2::GameVersion::kLod1_14B:
-    case d2::GameVersion::kLod1_14C: {
-      return Make_Game_RestoreDDrawPatch_LoD1_14A();
-    }
-
-    case d2::GameVersion::kClassic1_14D: {
-      return Make_Game_RestoreDDrawPatch_Classic1_14D();
-    }
-
-    case d2::GameVersion::kLod1_14D: {
-      return Make_Game_RestoreDDrawPatch_LoD1_14D();
-    }
-  }
-}
-
-} // namespace sgd2fdf::patches
+#endif // SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_PATCH_CLASSIC_1_14A_HPP_

--- a/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw_patch_classic_1_14d.cc
+++ b/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw_patch_classic_1_14d.cc
@@ -43,7 +43,7 @@
  *  work.
  */
 
-#include "game_restore_ddraw_patch_lod_1_14c.hpp"
+#include "game_restore_ddraw_patch_classic_1_14d.hpp"
 
 #include "../../../asm_x86_macro.h"
 #include "game_restore_ddraw.hpp"
@@ -52,20 +52,17 @@ namespace sgd2fdf::patches {
 namespace {
 
 __declspec(naked) void __cdecl InterceptionFunc_01() {
+  ASM_X86(lea ecx, dword ptr [ebp - 1244]);
+
   ASM_X86(push ebp);
   ASM_X86(mov ebp, esp);
 
   ASM_X86(push eax);
-  ASM_X86(push ecx);
-  ASM_X86(push edx);
 
-  ASM_X86(lea eax, dword ptr [ebp + 20]);
-  ASM_X86(push eax);
+  ASM_X86(push ecx);
   ASM_X86(call ASM_X86_FUNC(SGD2FDF_Game_ReadRegistryVideoMode));
   ASM_X86(add esp, 4);
 
-  ASM_X86(pop edx);
-  ASM_X86(pop ecx);
   ASM_X86(pop eax);
 
   ASM_X86(leave);
@@ -74,13 +71,13 @@ __declspec(naked) void __cdecl InterceptionFunc_01() {
 
 } // namespace
 
-std::vector<mapi::GamePatch> Make_Game_RestoreDDrawPatch_LoD1_14C() {
+std::vector<mapi::GamePatch> Make_Game_RestoreDDrawPatch_Classic1_14D() {
   std::vector<mapi::GamePatch> patches;
 
   // Get video mode settings from the registry.
   mapi::GameAddress game_address_01 = mapi::GameAddress::FromOffset(
       "Game.exe",
-      0x1F10
+      0x63D1
   );
 
   patches.push_back(
@@ -88,7 +85,7 @@ std::vector<mapi::GamePatch> Make_Game_RestoreDDrawPatch_LoD1_14C() {
           std::move(game_address_01),
           mapi::BranchType::kCall,
           InterceptionFunc_01,
-          0x1F1E - 0x1F10
+          0x63E3 - 0x63D1
       )
   );
 

--- a/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw_patch_classic_1_14d.hpp
+++ b/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw_patch_classic_1_14d.hpp
@@ -43,39 +43,17 @@
  *  work.
  */
 
-#include "game_restore_ddraw_patch.hpp"
+#ifndef SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_PATCH_CLASSIC_1_14D_HPP_
+#define SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_PATCH_CLASSIC_1_14D_HPP_
 
-#include "game_restore_ddraw_patch_classic_1_14a.hpp"
-#include "game_restore_ddraw_patch_classic_1_14d.hpp"
-#include "game_restore_ddraw_patch_lod_1_14a.hpp"
-#include "game_restore_ddraw_patch_lod_1_14d.hpp"
+#include <vector>
+
+#include <sgd2mapi.hpp>
 
 namespace sgd2fdf::patches {
 
-std::vector<mapi::GamePatch> Make_Game_RestoreDDrawPatch() {
-  d2::GameVersion running_game_version_id = d2::GetRunningGameVersionId();
+std::vector<mapi::GamePatch> Make_Game_RestoreDDrawPatch_Classic1_14D();
 
-  switch (running_game_version_id) {
-    case d2::GameVersion::kClassic1_14A:
-    case d2::GameVersion::kClassic1_14B:
-    case d2::GameVersion::kClassic1_14C: {
-      return Make_Game_RestoreDDrawPatch_Classic1_14A();
-    }
+} // namespace SGD2FDF::patches
 
-    case d2::GameVersion::kLod1_14A:
-    case d2::GameVersion::kLod1_14B:
-    case d2::GameVersion::kLod1_14C: {
-      return Make_Game_RestoreDDrawPatch_LoD1_14A();
-    }
-
-    case d2::GameVersion::kClassic1_14D: {
-      return Make_Game_RestoreDDrawPatch_Classic1_14D();
-    }
-
-    case d2::GameVersion::kLod1_14D: {
-      return Make_Game_RestoreDDrawPatch_LoD1_14D();
-    }
-  }
-}
-
-} // namespace sgd2fdf::patches
+#endif // SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_PATCH_CLASSIC_1_14D_HPP_

--- a/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw_patch_lod_1_14a.hpp
+++ b/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw_patch_lod_1_14a.hpp
@@ -43,39 +43,17 @@
  *  work.
  */
 
-#include "game_restore_ddraw_patch.hpp"
+#ifndef SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_PATCH_LOD_1_14A_HPP_
+#define SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_PATCH_LOD_1_14A_HPP_
 
-#include "game_restore_ddraw_patch_classic_1_14a.hpp"
-#include "game_restore_ddraw_patch_classic_1_14d.hpp"
-#include "game_restore_ddraw_patch_lod_1_14a.hpp"
-#include "game_restore_ddraw_patch_lod_1_14d.hpp"
+#include <vector>
+
+#include <sgd2mapi.hpp>
 
 namespace sgd2fdf::patches {
 
-std::vector<mapi::GamePatch> Make_Game_RestoreDDrawPatch() {
-  d2::GameVersion running_game_version_id = d2::GetRunningGameVersionId();
+std::vector<mapi::GamePatch> Make_Game_RestoreDDrawPatch_LoD1_14A();
 
-  switch (running_game_version_id) {
-    case d2::GameVersion::kClassic1_14A:
-    case d2::GameVersion::kClassic1_14B:
-    case d2::GameVersion::kClassic1_14C: {
-      return Make_Game_RestoreDDrawPatch_Classic1_14A();
-    }
+} // namespace SGD2FDF::patches
 
-    case d2::GameVersion::kLod1_14A:
-    case d2::GameVersion::kLod1_14B:
-    case d2::GameVersion::kLod1_14C: {
-      return Make_Game_RestoreDDrawPatch_LoD1_14A();
-    }
-
-    case d2::GameVersion::kClassic1_14D: {
-      return Make_Game_RestoreDDrawPatch_Classic1_14D();
-    }
-
-    case d2::GameVersion::kLod1_14D: {
-      return Make_Game_RestoreDDrawPatch_LoD1_14D();
-    }
-  }
-}
-
-} // namespace sgd2fdf::patches
+#endif // SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_PATCH_LOD_1_14A_HPP_

--- a/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw_patch_lod_1_14c.hpp
+++ b/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw_patch_lod_1_14c.hpp
@@ -43,61 +43,17 @@
  *  work.
  */
 
-#include "required_patches.hpp"
+#ifndef SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_PATCH_LOD_1_14C_HPP_
+#define SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_PATCH_LOD_1_14C_HPP_
 
-#include <algorithm>
+#include <vector>
 
-#include "d2ddraw_fix_corner_text_patch/d2ddraw_fix_corner_text_patch.hpp"
-#include "d2direct3d_fix_corner_text_patch/d2direct3d_fix_corner_text_patch.hpp"
-#include "d2direct3d_fix_display_mode_color_bits_patch/d2direct3d_fix_display_mode_color_bits_patch.hpp"
-#include "d2glide_fix_corner_text_patch/d2glide_fix_corner_text_patch.hpp"
-#include "game_restore_ddraw_patch/game_restore_ddraw_patch.hpp"
+#include <sgd2mapi.hpp>
 
 namespace sgd2fdf::patches {
 
-std::vector<mapi::GamePatch> MakeRequiredPatches() {
-  std::vector<mapi::GamePatch> game_patches;
+std::vector<mapi::GamePatch> Make_Game_RestoreDDrawPatch_LoD1_14C();
 
-  std::vector d2ddraw_fix_corner_text_patch =
-      Make_D2DDraw_FixCornerTextPatch();
-  game_patches.insert(
-      game_patches.end(),
-      std::make_move_iterator(d2ddraw_fix_corner_text_patch.begin()),
-      std::make_move_iterator(d2ddraw_fix_corner_text_patch.end())
-  );
+} // namespace SGD2FDF::patches
 
-  std::vector d2direct3d_fix_corner_text_patch =
-      Make_D2Direct3D_FixCornerTextPatch();
-  game_patches.insert(
-      game_patches.end(),
-      std::make_move_iterator(d2direct3d_fix_corner_text_patch.begin()),
-      std::make_move_iterator(d2direct3d_fix_corner_text_patch.end())
-  );
-
-  std::vector d2direct3d_fix_display_mode_color_bits_patch =
-      Make_D2Direct3D_FixDisplayModeColorBitsPatch();
-  game_patches.insert(
-      game_patches.end(),
-      std::make_move_iterator(d2direct3d_fix_display_mode_color_bits_patch.begin()),
-      std::make_move_iterator(d2direct3d_fix_display_mode_color_bits_patch.end())
-  );
-
-  std::vector d2glide_fix_corner_text_patch =
-      Make_D2Glide_FixCornerTextPatch();
-  game_patches.insert(
-      game_patches.end(),
-      std::make_move_iterator(d2glide_fix_corner_text_patch.begin()),
-      std::make_move_iterator(d2glide_fix_corner_text_patch.end())
-  );
-
-  std::vector game_restore_ddraw_patch = Make_Game_RestoreDDrawPatch();
-  game_patches.insert(
-      game_patches.end(),
-      std::make_move_iterator(game_restore_ddraw_patch.begin()),
-      std::make_move_iterator(game_restore_ddraw_patch.end())
-  );
-
-  return game_patches;
-}
-
-} // namespace sgd2fdf::patches
+#endif // SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_PATCH_LOD_1_14C_HPP_

--- a/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw_patch_lod_1_14d.cc
+++ b/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw_patch_lod_1_14d.cc
@@ -43,39 +43,53 @@
  *  work.
  */
 
-#include "game_restore_ddraw_patch.hpp"
-
-#include "game_restore_ddraw_patch_classic_1_14a.hpp"
-#include "game_restore_ddraw_patch_classic_1_14d.hpp"
-#include "game_restore_ddraw_patch_lod_1_14a.hpp"
 #include "game_restore_ddraw_patch_lod_1_14d.hpp"
 
+#include "../../../asm_x86_macro.h"
+#include "game_restore_ddraw.hpp"
+
 namespace sgd2fdf::patches {
+namespace {
 
-std::vector<mapi::GamePatch> Make_Game_RestoreDDrawPatch() {
-  d2::GameVersion running_game_version_id = d2::GetRunningGameVersionId();
+__declspec(naked) void __cdecl InterceptionFunc_01() {
+  ASM_X86(lea ecx, dword ptr [ebp - 1240]);
 
-  switch (running_game_version_id) {
-    case d2::GameVersion::kClassic1_14A:
-    case d2::GameVersion::kClassic1_14B:
-    case d2::GameVersion::kClassic1_14C: {
-      return Make_Game_RestoreDDrawPatch_Classic1_14A();
-    }
+  ASM_X86(push ebp);
+  ASM_X86(mov ebp, esp);
 
-    case d2::GameVersion::kLod1_14A:
-    case d2::GameVersion::kLod1_14B:
-    case d2::GameVersion::kLod1_14C: {
-      return Make_Game_RestoreDDrawPatch_LoD1_14A();
-    }
+  ASM_X86(push eax);
 
-    case d2::GameVersion::kClassic1_14D: {
-      return Make_Game_RestoreDDrawPatch_Classic1_14D();
-    }
+  ASM_X86(push ecx);
+  ASM_X86(call ASM_X86_FUNC(SGD2FDF_Game_ReadRegistryVideoMode));
+  ASM_X86(add esp, 4);
 
-    case d2::GameVersion::kLod1_14D: {
-      return Make_Game_RestoreDDrawPatch_LoD1_14D();
-    }
-  }
+  ASM_X86(pop eax);
+
+  ASM_X86(leave);
+  ASM_X86(ret);
+}
+
+} // namespace
+
+std::vector<mapi::GamePatch> Make_Game_RestoreDDrawPatch_LoD1_14D() {
+  std::vector<mapi::GamePatch> patches;
+
+  // Get video mode settings from the registry.
+  mapi::GameAddress game_address_01 = mapi::GameAddress::FromOffset(
+      "Game.exe",
+      0x659D
+  );
+
+  patches.push_back(
+      mapi::GamePatch::MakeGameBranchPatch(
+          std::move(game_address_01),
+          mapi::BranchType::kCall,
+          InterceptionFunc_01,
+          0x65AF - 0x659D
+      )
+  );
+
+  return patches;
 }
 
 } // namespace sgd2fdf::patches

--- a/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw_patch_lod_1_14d.hpp
+++ b/SlashGaming-Diablo-II-Free-Display-Fix/src/patches/required/game_restore_ddraw_patch/game_restore_ddraw_patch_lod_1_14d.hpp
@@ -43,39 +43,17 @@
  *  work.
  */
 
-#include "game_restore_ddraw_patch.hpp"
+#ifndef SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_PATCH_LOD_1_14D_HPP_
+#define SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_PATCH_LOD_1_14D_HPP_
 
-#include "game_restore_ddraw_patch_classic_1_14a.hpp"
-#include "game_restore_ddraw_patch_classic_1_14d.hpp"
-#include "game_restore_ddraw_patch_lod_1_14a.hpp"
-#include "game_restore_ddraw_patch_lod_1_14d.hpp"
+#include <vector>
+
+#include <sgd2mapi.hpp>
 
 namespace sgd2fdf::patches {
 
-std::vector<mapi::GamePatch> Make_Game_RestoreDDrawPatch() {
-  d2::GameVersion running_game_version_id = d2::GetRunningGameVersionId();
+std::vector<mapi::GamePatch> Make_Game_RestoreDDrawPatch_LoD1_14D();
 
-  switch (running_game_version_id) {
-    case d2::GameVersion::kClassic1_14A:
-    case d2::GameVersion::kClassic1_14B:
-    case d2::GameVersion::kClassic1_14C: {
-      return Make_Game_RestoreDDrawPatch_Classic1_14A();
-    }
+} // namespace SGD2FDF::patches
 
-    case d2::GameVersion::kLod1_14A:
-    case d2::GameVersion::kLod1_14B:
-    case d2::GameVersion::kLod1_14C: {
-      return Make_Game_RestoreDDrawPatch_LoD1_14A();
-    }
-
-    case d2::GameVersion::kClassic1_14D: {
-      return Make_Game_RestoreDDrawPatch_Classic1_14D();
-    }
-
-    case d2::GameVersion::kLod1_14D: {
-      return Make_Game_RestoreDDrawPatch_LoD1_14D();
-    }
-  }
-}
-
-} // namespace sgd2fdf::patches
+#endif // SGD2FDF_PATCHES_REQUIRED_GAME_RESTORE_DDRAW_PATCH_D2DDRAW_GAME_RESTORE_DDRAW_PATCH_LOD_1_14D_HPP_


### PR DESCRIPTION
Video mode is now read in from the registry, similar to 1.13D and below. This also restores the ability to select the render mode, including DirectDraw mode.