### PR TITLE
Add VC6 DLL linking fix batch script

### DIFF
--- a/Fix for VC6.bat
+++ b/Fix for VC6.bat
@@ -1,0 +1,1 @@
+powershell -Command "(Get-Content -Path ./third_party/SGD2MAPI98/SGD2MAPIc/SGD2MAPIc.dsp) | %%{$_ -replace '/libpath:""../third_party/MDC/MDC/', '/libpath:""""../../../third_party/MDC/MDC/'} | Set-Content -Path ./third_party/SGD2MAPI98/SGD2MAPIc/SGD2MAPIc.dsp"


### PR DESCRIPTION
The non-static linking version of the DLL has issues with compilation for SGD2MAPI98. In order to fix this, a batch script is added to redirect the submodule linking parameters to this project's MDC submodule.